### PR TITLE
Update index.md

### DIFF
--- a/pages/usabilita/index.md
+++ b/pages/usabilita/index.md
@@ -4,24 +4,16 @@ title: Usabilità
 published: true
 ---
 
-L'usabilità misura l'efficienza delle informazioni e degli strumenti messi a disposizione degli utenti nel raggiungimento di un obiettivo.
+L'usabilità è definita come "il grado in cui un determinato utente può raggiungere il proprio obiettivo con efficacia, efficienza e soddisfazione, in uno specifico contesto d’uso". Si può applicare ad un prodotto, un sito o un servizio. 
 
-Una buona usabilità di un sito web permette di garantire alla più vasta platea dei cittadini un accesso ai servizi in forma semplice e inclusiva. 
+Su un sito l'usabilità misura l'efficacia e l'efficienza delle informazioni e degli strumenti messi a disposizione degli utenti nel raggiungimento di un obiettivo. Lo scopo è migliorare la qualità dell’esperienza utente attraverso una navigazione chiara, contenuti comprensibili, procedure facili, efficienti, gradevoli e a prova di errori.
+
+Una buona usabilità di un sito web permette di garantire alla più vasta platea dei cittadini un accesso ai servizi in forma semplice e inclusiva.
 
 Porre il cittadino reale, con le sue necessità e le sue capacità, al centro della progettazione dei servizi erogati online dalle pubbliche amministrazioni è il primo e necessario passo per l’applicazione dei principi di Human-centered design.
 
-Scopo dell’usabilità è migliorare la qualità dell’esperienza utente attraverso una navigazione chiara, comprensibile, facile, efficiente e gradevole. Un prodotto usabile, sia esso un oggetto o un sito, consente all'utente di raggiungere il proprio obiettivo con efficacia, efficienza e soddisfazione, in uno specifico contesto d’uso.
-
-La definizione di usabilità è costituita dalle seguenti sotto-caratteristiche: 
-*	riconoscibilità: il prodotto è ritenuto adatto per le esigenze dell’utente;
-*	apprendibilità: il prodotto è facilmente apprendibile dall’utente per raggiungere i suoi obiettivi; 
-*	operabilità: il prodotto è facilmente operabile e controllabile; 
-*	protezione dagli errori: il sistema protegge gli utenti da eventuali errori; 
-*	esteticità dell’interfaccia: l’interfaccia dà piacere e soddisfazione all’utente;
-*	accessibilità: il prodotto e il sistema possono essere utilizzati da persone con il più vasto spettro di caratteristiche e capacità (persone con disabilità, incluse quelle dovute all’età).
-
 Per approfondimenti sugli standard ISO:
 
-* [ISO 9241-11:1998](http://www.iso.org/iso/catalogue_detail.htm?csnumber=16883)
-
 * [ISO 9241-210:2010](http://www.iso.org/iso/catalogue_detail.htm?csnumber=52075)
+
+* [ISO/IEC 25010:2011](http://www.iso.org/iso/catalogue_detail.htm?csnumber=35733)


### PR DESCRIPTION
Propongo l'eliminazione dell'articolazione in 6 sottocomponenti dell'usabilità (e la ristrutturazione del testo per inserire in cima la definizione ripresa dalla 9241). Al tempo stesso, per chi volesse approfondire, propongo di introdurre però il link alla norma da cui erano tratte (la 25010), che prima era assente.

Per la modifca propongo diverse ragioni:

- Benchè fosse citata anche la definizione 9241 più utilizzata in ambito web, per la sua lunghezza ed evidenza risultava prevalente quella della 25010, generando potenziali confusioni, visto che vi sono molte fonti in ambito pubblico che usano la 9241 come definizione base
- La definizione della 25010 contiene proprietà poco spiegate e include l'accessibilità, che in Italia è normata da una legge a parte e dunque rischia di creare ambiguità e confusioni fra usabilità e accessibilità
- La definizione 25010 è parte di un modello più ampio: citarla senza citare quello rischia di dar l'idea che efficacia, efficienza e soddisfazione non siano determinanti, e lo siano invece aspetti come l'esteticità
- La definizione 25010 è di qualità del prodotto, e non di qualità in uso; come tale richiede la definizione di criteri di valutazione specifici, che qui non sono menzionati;
- Al contrario, la definizione 9241 è congruente con i metodi di valutazione (protocollo eGLU) e i principi ripresi dai decreti della 4/2004 indicati in altre parti del testo.
- Infine, la definizione della 9241 è autosufficiente: è sensata e comprensibile anche senza introdurre altri dettagli sul processo HCD, o altri aspetti di qualità del software; è breve e relativamente comprensibile senza bisogno di ulteriori approfondimenti.

Preciso che non ho nulla contro la 20510 (specialmente in ambito software la trovo utile): semplicemente la sua introduzione senza più ampia spiegazione risulta a mio parere problematica per le ragioni che spero di aver spiegato.