### PR TITLE
Rimozione dei title=" dai link e caricare Google Analytics in modo asincrono

### DIFF
--- a/template/partials/footer.html
+++ b/template/partials/footer.html
@@ -66,6 +66,7 @@
   b[l].l = +new Date;
   e = o.createElement(i);
   r = o.getElementsByTagName(i)[0];
+  e.async = 1;
   e.src = '//www.google-analytics.com/analytics.js';
   r.parentNode.insertBefore(e, r)
 }(window, document, 'script', 'ga'));

--- a/template/partials/footer.html
+++ b/template/partials/footer.html
@@ -31,11 +31,11 @@
     </div>
     <div class="row">
       <ul class="col-xs-12 footer__links clearfix">
-        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/privacy-policy/" title="privacy policy">Privacy</a></li>
-        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/note-legali/" title="note legali">Note legali</a></li>
-        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/credits/" title="credits">Credits</a></li>
-        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/showcase/" title="credits">Showcase</a></li>
-        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/contatti/" title="credits">Contatti</a></li>
+        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/privacy-policy/">Privacy</a></li>
+        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/note-legali/">Note legali</a></li>
+        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/credits/">Credits</a></li>
+        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/showcase/">Showcase</a></li>
+        <li><a href="{{ data.config.site.baseurl }}{{ data.config.site.htmlDir }}/contatti/">Contatti</a></li>
       </ul>
     </div>
   </div>

--- a/template/partials/footer.html
+++ b/template/partials/footer.html
@@ -1,5 +1,5 @@
 
-  <a href="#page_top" title="torna all'inizio del contenuto" class="sr-only">torna all'inizio del contenuto</a>
+  <a href="#page_top" class="sr-only">torna all’inizio del contenuto</a>
 
 </div><!-- container -->
 
@@ -41,7 +41,7 @@
   </div>
 </footer>
 
-<a href="#page_top" title="torna all'inizio del contenuto" class="scrollto_top"><span><span class="sr-only">torna all'inizio del contenuto</span></span></a>
+<a href="#page_top" class="scrollto_top"><span><span class="sr-only">torna all'inizio del contenuto</span></span></a>
 
 <p class="cookie-message sr-only" role="alert">
   Questo sito utilizza cookie tecnici, analytics e di terze parti. Proseguendo nella navigazione accetti l’utilizzo dei cookie.


### PR DESCRIPTION
In questo caso i link hanno un attributo «title» che è lo stesso contenuto del testo che c'è dentro il link stesso. Dettaglio inutile per le tecnologie assistive e non offre alcun vantaggio per gli utenti.